### PR TITLE
Inheriting from docker-redhawk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,28 @@
-FROM centos:6
+FROM docker-redhawk
 MAINTAINER Ryan Bauman <ryanbauman@gmail.com>
 
-#Add REDHAWK yum repo
-COPY redhawk.repo /etc/yum.repos.d/
-
-#Install REDHAWK
-RUN yum update -y && \
-    yum install -y epel-release && \
-    yum install -y redhawk-devel \
-                   redhawk-sdrroot-dev-mgr \
-                   redhawk-sdrroot-dom-mgr \
-                   redhawk-sdrroot-dom-profile \
-                   bulkioInterfaces \
-                   burstioInterfaces \
-                   frontendInterfaces \
-                   GPP && \
-                   yum clean all
-
-
-#Configure omniORB
-COPY omniORB.cfg /etc/
-
-#Configure default user
-RUN mkdir -p /home/redhawk
-RUN cp /etc/skel/.bash* /home/redhawk
-RUN chown -R redhawk. /home/redhawk
-RUN usermod -a -G wheel --shell /bin/bash redhawk
-
-#Define environment
-ENV HOME /home/redhawk
-ENV OSSIEHOME /usr/local/redhawk/core
-ENV SDRROOT /var/redhawk/sdr
-ENV PYTHONPATH /usr/local/redhawk/core/lib64/python:/usr/local/redhawk/core/lib/python
-ENV PATH /usr/local/redhawk/core/bin:/usr/lib64/qt-3.3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-WORKDIR /home/redhawk
-USER redhawk
-
-#Run nodeconfig
-RUN /var/redhawk/sdr/dev/devices/GPP/python/nodeconfig.py --silent \
+# Run nodeconfig as RHUSER
+USER ${RHUSER}
+WORKDIR ${SDRROOT}
+RUN dev/devices/GPP/python/nodeconfig.py --silent \
     --clean \
     --gpppath=/devices/GPP \
     --disableevents \
     --domainname=REDHAWK_DEV \
-    --sdrroot=/var/redhawk/sdr \
+    --sdrroot=${SDRROOT} \
     --inplace \
     --nodename DevMgr_default
 
-#If being used as base image; set user root and update
+# Set user back to root.
 ONBUILD USER root
-ONBUILD RUN yum update -y && yum clean all
 
-ENTRYPOINT ["/usr/local/redhawk/core/bin/nodeBooter"]
+# Re-forward environment variables downstream from upstream
+ONBUILD ENV RHUSER ${RHUSER}
+ONBUILD ENV HOME ${HOME}
+ONBUILD ENV OSSIEHOME ${OSSIEHOME}
+ONBUILD ENV SDRROOT ${SDRROOT}
+ONBUILD ENV PYTHONPATH ${PYTHONPATH}
+ONBUILD ENV PATH ${PATH}
+
+ENTRYPOINT ${OSSIEHOME}/bin/nodeBooter
 CMD ["--version"]

--- a/omniORB.cfg
+++ b/omniORB.cfg
@@ -1,3 +1,0 @@
-InitRef = NameService=corbaname::127.0.0.1:2809
-InitRef = EventService=corbaloc::127.0.0.1:11169/omniEvents
-supportBootstrapAgent = 1

--- a/redhawk.repo
+++ b/redhawk.repo
@@ -1,5 +1,0 @@
-[redhawk]
-name=REDHAWK 1.10
-baseurl=http://yum.axiosengineering.com/redhawk/1.10/el6/x86_64/
-enabled=1
-gpgcheck=0


### PR DESCRIPTION
This going along with the other pull request to show what I was describing about inheriting the efforts of the docker-redhawk image into downstream images, and so-on.  The echo'd `ONBUILD` statements help nudge those values down the line again since ONBUILD is not inherited by grandchildren (per docker's documentation).